### PR TITLE
adding Dockerfile and CircleCI orbs to build;

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,36 @@
+version: 2.1
+
+orbs:
+  # https://circleci.com/orbs/registry/orb/circleci/docker-publish
+  docker-publish: circleci/docker-publish@0.1.3
+workflows:
+
+  # This workflow will be run on all branches but master (to test)
+  # Since there is no python module, versions coincide with Github commit SHAs
+  build_without_publishing_job:
+    jobs:
+      - docker-publish/publish:
+          image: poldracklab/coupling
+          deploy: false
+          filters:
+            branches:
+              ignore: 
+                - master
+
+  # This workflow will deploy images on merge to master only
+  docker_with_lifecycle:
+    jobs:
+      # Deploy a container tagged with latest
+      - docker-publish/publish:
+          image: poldracklab/coupling
+          tag: latest
+          filters:
+            branches:
+             only: master
+      # Deploy a container tagged with Github commit
+      - docker-publish/publish:
+          image: poldracklab/coupling
+          filters:
+            branches:
+             only: master
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM continuumio/miniconda3
+
+# docker build -t poldracklab/coupling .
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV LC_ALL C.UTF-8
+ENV LANG C.UTF-8
+
+RUN apt-get update && \
+    apt-get install -y git wget && \
+    mkdir -p /code && \
+    conda update -n base -c defaults conda && \
+    conda install -y pandas==0.18.0 numpy
+
+
+ADD . /code
+WORKDIR /code
+RUN chmod u+x /code/coupling.py
+ENTRYPOINT ["python"]
+CMD ["/code/coupling.py"]


### PR DESCRIPTION
This pull request will test the continuous integration on CircleCI to build the Dockerfile. Merging will deploy the tagged container as "latest" and according to the shasum. Note that we install pandas 0.18.0 which has a warning about the function (but it's not deprecated yet). We will need to test the container (someone that has data will need to do this).